### PR TITLE
Enforce function arguments with exception or type-hint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor/
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 vendor/
-.idea/

--- a/src/Exception/ActualToStringTrait.php
+++ b/src/Exception/ActualToStringTrait.php
@@ -2,14 +2,12 @@
 
 namespace TomPHP\Transform\Exception;
 
-
 trait ActualToStringTrait
 {
-
     /**
      * Return human readable string representation of a variable.
      *
-     * @param mixed $actual
+     * @param  mixed  $actual
      * @return string
      */
     private static function actualToString($actual)
@@ -19,7 +17,7 @@ trait ActualToStringTrait
         }
 
         if (is_object($actual)) {
-            return 'instance of ' . get_class($actual);
+            return 'instance of '.get_class($actual);
         }
 
         return sprintf('%s', $actual);

--- a/src/Exception/ActualToStringTrait.php
+++ b/src/Exception/ActualToStringTrait.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace TomPHP\Transform\Exception;
+
+
+trait ActualToStringTrait
+{
+
+    /**
+     * Return human readable string representation of a variable.
+     *
+     * @param mixed $actual
+     * @return string
+     */
+    private static function actualToString($actual)
+    {
+        if (is_array($actual)) {
+            return 'Array';
+        }
+
+        if (is_object($actual)) {
+            return 'instance of ' . get_class($actual);
+        }
+
+        return sprintf('%s', $actual);
+    }
+}

--- a/src/Exception/ExpectedObjectTrait.php
+++ b/src/Exception/ExpectedObjectTrait.php
@@ -2,10 +2,8 @@
 
 namespace TomPHP\Transform\Exception;
 
-
 trait ExpectedObjectTrait
 {
-
     /**
      * @param string $variable
      * @param mixed  $actual

--- a/src/Exception/ExpectedObjectTrait.php
+++ b/src/Exception/ExpectedObjectTrait.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace TomPHP\Transform\Exception;
+
+
+trait ExpectedObjectTrait
+{
+
+    /**
+     * @param string $variable
+     * @param mixed  $actual
+     *
+     * @return self
+     */
+    public static function expectedObject($variable, $actual)
+    {
+        return new self(sprintf(
+            '$%s was expected to be an object; got %s.',
+            $variable,
+            self::actualToString($actual)
+        ));
+    }
+}

--- a/src/Exception/ExpectedStringTrait.php
+++ b/src/Exception/ExpectedStringTrait.php
@@ -2,10 +2,8 @@
 
 namespace TomPHP\Transform\Exception;
 
-
 trait ExpectedStringTrait
 {
-
     /**
      * @param string $variable
      * @param mixed  $actual

--- a/src/Exception/ExpectedStringTrait.php
+++ b/src/Exception/ExpectedStringTrait.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace TomPHP\Transform\Exception;
+
+
+trait ExpectedStringTrait
+{
+
+    /**
+     * @param string $variable
+     * @param mixed  $actual
+     *
+     * @return self
+     */
+    public static function expectedString($variable, $actual)
+    {
+        return new self(sprintf(
+            '$%s was expected to be a string; got %s.',
+            $variable,
+            self::actualToString($actual)
+        ));
+    }
+}

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -4,18 +4,7 @@ namespace TomPHP\Transform\Exception;
 
 class InvalidArgumentException extends \InvalidArgumentException implements Exception
 {
-    /**
-     * @param string $variable
-     * @param mixed  $actual
-     *
-     * @return self
-     */
-    public static function expectedString($variable, $actual)
-    {
-        return new self(sprintf(
-            '$%s was expected to be a string; got %s',
-            $variable,
-            is_object($actual) ? get_class($actual) : $actual
-        ));
-    }
+    use ActualToStringTrait;
+    use ExpectedStringTrait;
+    use ExpectedObjectTrait;
 }

--- a/src/Exception/UnexpectedValueException.php
+++ b/src/Exception/UnexpectedValueException.php
@@ -9,8 +9,8 @@ class UnexpectedValueException extends \UnexpectedValueException implements Exce
     use ExpectedObjectTrait;
 
     /**
-     * @param object|string $object
-     * @param string $method
+     * @param  object|string                                        $object
+     * @param  string                                               $method
      * @return \TomPHP\Transform\Exception\InvalidArgumentException
      */
     public static function expectedMethod($object, $method)

--- a/src/Exception/UnexpectedValueException.php
+++ b/src/Exception/UnexpectedValueException.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace TomPHP\Transform\Exception;
+
+class UnexpectedValueException extends \UnexpectedValueException implements Exception
+{
+    use ActualToStringTrait;
+    use ExpectedStringTrait;
+    use ExpectedObjectTrait;
+
+    /**
+     * @param object|string $object
+     * @param string $method
+     * @return \TomPHP\Transform\Exception\InvalidArgumentException
+     */
+    public static function expectedMethod($object, $method)
+    {
+        is_object($object) and $object = get_class($object);
+
+        return new self(sprintf(
+            '"%s::%s() is not a valid method."',
+            self::actualToString($object),
+            self::actualToString($method)
+        ));
+    }
+}

--- a/src/transform.php
+++ b/src/transform.php
@@ -3,6 +3,7 @@
 namespace TomPHP\Transform;
 
 use TomPHP\Transform\Exception\InvalidArgumentException;
+use TomPHP\Transform\Exception\UnexpectedValueException;
 
 /**
  * Represents a placeholder in an argument list.
@@ -17,7 +18,7 @@ const __ = 'Super Unique Placeholder String - 6f74f07a-bc60-494a-93e0-eefedb6984
  *
  * @return \Closure
  */
-function chain(...$fns)
+function chain(callable ...$fns)
 {
     return function ($value) use ($fns) {
         return array_reduce(
@@ -45,13 +46,23 @@ function __()
  * the result.
  *
  * @param string $methodName
- * @param array  $arguments
- *
+ * @param array  $args
  * @return \Closure
+ * @throws \TomPHP\Transform\Exception\ExpectedStringTrait
  */
 function callMethod($methodName, ...$args)
 {
+    if (!is_string($methodName)) {
+        throw InvalidArgumentException::expectedString('methodName', $methodName);
+    }
+
     return function ($object) use ($methodName, $args) {
+        if (!is_object($object)) {
+            throw UnexpectedValueException::expectedObject('object', $object);
+        } elseif (!method_exists($object, $methodName)) {
+            throw  UnexpectedValueException::expectedObject($object, $methodName);
+        }
+
         return $object->$methodName(...$args);
     };
 }
@@ -118,7 +129,7 @@ function getProperty($name)
  * Returns a transformer calls the given callable with its value as the
  * argument and returns the result.
  *
- * @param callable $name      Providing an array will walk multiple levels into
+ * @param callable $callable  Providing an array will walk multiple levels into
  *                            the array.
  * @param mixed[]  $arguments Use __ to indicate where the value should be
  *                            placed in the argument list.
@@ -143,8 +154,8 @@ function argumentTo(callable $callable, array $arguments = [__])
  * Returns a transformer which prepends $prefix onto its value.
  *
  * @param string $prefix
- *
  * @return \Closure
+ * @throws \TomPHP\Transform\Exception\ExpectedStringTrait
  */
 function prepend($prefix)
 {
@@ -153,6 +164,10 @@ function prepend($prefix)
     }
 
     return function ($value) use ($prefix) {
+        if (!is_string($value) && ! (is_object($value) && method_exists($value, '__toString'))) {
+            throw UnexpectedValueException::expectedString('value', $value);
+        }
+
         return $prefix.$value;
     };
 }
@@ -161,8 +176,8 @@ function prepend($prefix)
  * Returns a transformer which appends $suffix onto its value.
  *
  * @param string $suffix
- *
  * @return \Closure
+ * @throws \TomPHP\Transform\Exception\ExpectedStringTrait
  */
 function append($suffix)
 {
@@ -171,6 +186,10 @@ function append($suffix)
     }
 
     return function ($value) use ($suffix) {
+        if (!is_string($value) && ! (is_object($value) && method_exists($value, '__toString'))) {
+            throw UnexpectedValueException::expectedString('value', $value);
+        }
+
         return $value.$suffix;
     };
 }

--- a/tests/Exception/InvalidArgumentExceptionTest.php
+++ b/tests/Exception/InvalidArgumentExceptionTest.php
@@ -26,7 +26,7 @@ final class InvalidArgumentExceptionTest extends PHPUnit_Framework_TestCase
         $exception = InvalidArgumentException::expectedString('param', 101);
 
         $this->assertEquals(
-            '$param was expected to be a string; got 101',
+            '$param was expected to be a string; got 101.',
             $exception->getMessage()
         );
     }
@@ -37,7 +37,7 @@ final class InvalidArgumentExceptionTest extends PHPUnit_Framework_TestCase
         $exception = InvalidArgumentException::expectedString('param', new \stdClass());
 
         $this->assertEquals(
-            '$param was expected to be a string; got stdClass',
+            '$param was expected to be a string; got instance of stdClass.',
             $exception->getMessage()
         );
     }


### PR DESCRIPTION
This PR aim to fix the issues explained in #5.

It does:
- Uses type-hint wherever possible to enforce argument type
- Introduce `UnexpectedValueException` class
- When an unexpected argument is received by a transformer callbacks thows an `UnexpectedValueException`
- Introduce some traits to share methods between `UnexpectedValueException` and `InvalidArgumentException`
- Minor changes to `InvalidArgumentException` messages
